### PR TITLE
add formal checks

### DIFF
--- a/.github/workflows-disabled/test.yml
+++ b/.github/workflows-disabled/test.yml
@@ -19,6 +19,10 @@ jobs:
       #  uses: jodersky/setup-mill@v0.2.3
       #  with:
       #    mill-version: 0.9.7
+      - name: Install OSS CAD Tools (for model checking)
+        uses: YosysHQ/setup-oss-cad-suite@v1
+        with:
+          osscadsuite-version: '2022-12-08'
       - name: Cache Scala
         uses: coursier/cache-action@v5
       - name: SBT Test

--- a/src/test/scala/fifo/FifoFormalSpec.scala
+++ b/src/test/scala/fifo/FifoFormalSpec.scala
@@ -1,0 +1,43 @@
+package fifo
+
+import chisel3._
+import chiseltest._
+import chiseltest.formal._
+import org.scalatest.freespec.AnyFreeSpec
+import testutil._
+
+
+
+class FifoFormalSpecModule(depth: Int, factory : () => FifoIfc[UInt]) extends Module {
+  // instantiate DUT and create wrapper
+  val dut = Module(factory())
+  val io = IO(chiselTypeOf(dut.io)) ; io <> dut.io
+  // add assertions
+  MagicPacketTracker(dut.io.inp, dut.io.out, depth, debugPrint = true)
+}
+
+
+class FifoFormalSpec(tag: String, factory : () => FifoIfc[UInt], depth: Int) extends AnyFreeSpec with ChiselScalatestTester with TestParams with Formal {
+  val DefaultAnnos = Seq(BoundedCheck(depth * 2 + 1), BtormcEngineAnnotation)
+  s"$tag should work" in {
+    verify(new FifoFormalSpecModule(depth, factory), DefaultAnnos)
+  }
+}
+
+
+
+
+class DecoupledStageSpecFormal extends FifoFormalSpec ("DecoupledStage", () => new DecoupledStage(UInt(16.W)), 1)
+class MooreStageSpecFormal extends FifoFormalSpec ("MooreStage", () => new MooreStage(UInt(16.W)), 2)
+class BlockedStageSpecFormal extends FifoFormalSpec ("BlockedStage", () => new BlockedStage(UInt(16.W)), 1)
+class HalfStageSpecFormal extends FifoFormalSpec ("HalfStage", () => new HalfStage(UInt(16.W)), 1)
+class Chain_8_DecoupledStage_16SpecFormal extends FifoFormalSpec ("Chain_8_DecoupledStage", () => new Chain(8, UInt(16.W), (x: UInt) => new DecoupledStage(x)), depth = 8)
+// 16 is a little deep for a quick formal check, it would take more than 1h on my laptop, thus we reduced the chain depth to 3
+class Chain_3_MooreStage_16SpecFormal extends FifoFormalSpec ("Chain_3_MooreStage", () => new Chain(3, UInt(16.W), (x: UInt) => new MooreStage(x)), depth = 3 * 2)
+// depth reduced to 5 to make formal check faster
+class Chain_5_BlockedStage_16SpecFormal extends FifoFormalSpec ("Chain_5_BlockedStage", () => new Chain(5, UInt(16.W), (x: UInt) => new BlockedStage(x)), depth = 5)
+class Chain_8_HalfStage_16SpecFormal extends FifoFormalSpec ("Chain_8_HalfStage", () => new Chain(8, UInt(16.W), (x: UInt) => new HalfStage(x)), depth = 8)
+
+// depth reduced to make formal check faster
+class QueueFifo_5_16SpecFormal extends FifoFormalSpec ("QueueFifo_5", () => new QueueFifo(5, UInt(16.W)), depth = 5)
+class QueueFifoAlt_5_16SpecFormal extends FifoFormalSpec ("QueueFifoAlt_5", () => new QueueFifoAlt(5, UInt(16.W)), depth = 5)

--- a/src/test/scala/fifo/MagicPacketTracker.scala
+++ b/src/test/scala/fifo/MagicPacketTracker.scala
@@ -1,0 +1,111 @@
+// this file was copied from chiseltest 0.6:
+// https://github.com/ucb-bar/chiseltest/blob/main/src/main/scala/chiseltest/formal/vips/MagicPacketTracker.scala
+package fifo
+
+import chisel3._
+import chisel3.experimental.IO
+import chisel3.util._
+
+/** Tracks random packets for formally verifying FIFOs
+ *
+ *  This ensures that when some data enters the FIFO, it will always be dequeued after the correct number of elements.
+ *  So essentially we are verifying data integrity. Note that this does not imply that the FIFO has no bugs
+ *  since e.g., a FIFO that never allows elements to be enqueued would easily pass our assertions.
+ *
+ *  This module was inspired by the MagicPacketTracker used in the evaluation of the following paper:
+ *  Mann, Makai, and Clark Barrett. "Partial order reduction for deep bug finding in synchronous hardware.", CAV'20.
+ */
+object MagicPacketTracker {
+  def apply[D <: Data](enq: ValidIO[D], deq: ValidIO[D], depth: Int, debugPrint: Boolean): Unit = {
+    val tracker = Module(new MagicPacketTracker(chiselTypeOf(enq.bits), depth, debugPrint))
+    tracker.enq := enq
+    tracker.deq := deq
+    val startTracking = IO(Input(Bool()))
+    tracker.startTracking := startTracking
+  }
+  def apply[D <: Data](enq: ValidIO[D], deq: ValidIO[D], depth: Int): Unit =
+    apply(enq, deq, depth, debugPrint = false)
+  def apply[D <: Data](enq: DecoupledIO[D], deq: DecoupledIO[D], depth: Int, debugPrint: Boolean): Unit =
+    apply(asValid(enq), asValid(deq), depth, debugPrint)
+  def apply[D <: Data](enq: DecoupledIO[D], deq: DecoupledIO[D], depth: Int): Unit =
+    apply(asValid(enq), asValid(deq), depth)
+
+  private def asValid[D <: Data](port: DecoupledIO[D]): ValidIO[D] = {
+    val validIO = Wire(ValidIO(chiselTypeOf(port.bits)))
+    validIO.valid := port.fire
+    validIO.bits := port.bits
+    validIO
+  }
+}
+
+class MagicPacketTracker[D <: Data] private (dataTpe: D, fifoDepth: Int, debugPrint: Boolean) extends Module {
+  require(fifoDepth > 0, "Fifo depth needs to be positive!")
+  val enq = IO(Input(ValidIO(dataTpe)))
+  val deq = IO(Input(ValidIO(dataTpe)))
+
+  // count the number of elements in the fifo
+  val elementCount = RegInit(0.U(log2Ceil(fifoDepth + 1).W))
+  val nextElementCount = Mux(
+    enq.fire && !deq.fire,
+    elementCount + 1.U,
+    Mux(!enq.fire && deq.fire, elementCount - 1.U, elementCount)
+  )
+  elementCount := nextElementCount
+
+  // track a random "magic" packet through the fifo
+  val startTracking = IO(Input(Bool()))
+  val isActive = RegInit(false.B)
+  val packetValue = Reg(chiselTypeOf(enq.bits))
+  val packetCount = Reg(chiselTypeOf(elementCount))
+
+  when(!isActive && enq.fire && startTracking) {
+    when(deq.fire && elementCount === 0.U) {
+      assert(
+        enq.bits.asUInt === deq.bits.asUInt,
+        "element should pass through the fifo, but %x != %x",
+        enq.bits.asUInt,
+        deq.bits.asUInt
+      )
+    }.otherwise {
+      isActive := true.B
+      packetValue := enq.bits
+      packetCount := nextElementCount
+    }
+  }
+
+  when(isActive && deq.fire) {
+    packetCount := packetCount - 1.U
+    when(packetCount === 1.U) {
+      assert(
+        packetValue.asUInt === deq.bits.asUInt,
+        "element should be dequeued in this cycle, but %x != %x",
+        packetValue.asUInt,
+        deq.bits.asUInt
+      )
+      isActive := false.B
+    }
+  }
+
+  // detect element count overflow
+  when(elementCount === fifoDepth.U) {
+    val shouldIncrement = enq.fire && !deq.fire
+    assert(
+      !shouldIncrement,
+      "MagicPacketTracker: element counter is overflowing %d -> %d\n" +
+        "This could indicate either a bug in your FIFO design, or an insufficient depth provided to the MagicPacketTracker constructor.",
+      elementCount,
+      nextElementCount
+    )
+  }
+
+  // printout to help debug counter examples
+  if (debugPrint) {
+    val cycle = RegInit(0.U(8.W)); cycle := cycle + 1.U
+    printf(p"step: ${cycle} ----------------------------------\n")
+    printf(p"element count: ${elementCount} -> ${nextElementCount}\n")
+    when(enq.fire) { printf(p"[${enq.bits}]") }
+    when(enq.fire || deq.fire) { printf(" --> ") }
+    when(deq.fire) { printf(p"[${deq.bits}]") }
+    when(enq.fire || deq.fire) { printf("\n") }
+  }
+}

--- a/src/test/scala/pla/PlaFormalSpec.scala
+++ b/src/test/scala/pla/PlaFormalSpec.scala
@@ -1,0 +1,31 @@
+package pla
+
+import chisel3._
+import chisel3.util.PopCount
+import chiseltest._
+import chiseltest.formal._
+import org.scalatest.freespec.AnyFreeSpec
+import testutil._
+
+
+class PlaSpecModule(cubes : Seq[String], foo: UInt => Bool) extends Module {
+  val dut = Module(new Pla(cubes))
+  val inp = IO(Input(chiselTypeOf(dut.inp)))
+  dut.inp := inp
+  val expected = foo(inp)
+  val actual = dut.out
+  assert(expected === actual, "%x != %x", expected, actual)
+}
+
+
+class PlaFormalSpec extends  AnyFreeSpec with ChiselScalatestTester with TestParams with Formal {
+  val DefaultAnnos = Seq(BoundedCheck(1), Z3EngineAnnotation)
+
+  "Maj should calculate 3-input majority" in {
+    verify(new PlaSpecModule(Seq("11-", "-11", "1-1"), inp => PopCount(inp) > 1.U), DefaultAnnos)
+  }
+
+  "Xor should calculate three input parity" in {
+    verify(new PlaSpecModule(Seq("100", "010", "001", "111"), inp => PopCount(inp).extract(0)), DefaultAnnos)
+  }
+}


### PR DESCRIPTION
The `QueueFifoAlt_5_16SpecFormal` fails because the `QueueFifoAlt` has a depth that is hard-coded to `16`. Not sure if this is by design or an actual bug.